### PR TITLE
Mount user's home directory by default (read only) for convience

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://192.168.254.1
 
 I first needed to use this feature in 2021 so I'll just describe the workaround I used to access a media image file:
 
-On Linux based hosts, your $HOME directory will automatically be mounted to /home/ffuser/home_home/
+On Linux based hosts, your $HOME directory will automatically be mounted to /home/ffuser/home_home/ (read only)
 
 You can also copy image files into your host directory: `~/.javafox/.mozilla`.  In the contained javafox you can then browse to the `HOME/.mozilla` directory and find the image file there.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ https://192.168.254.1
 
 I first needed to use this feature in 2021 so I'll just describe the workaround I used to access a media image file:
 
-You can copy image files into your host directory: `~/.javafox/.mozilla`.  In the contained javafox you can browse into the `HOME/.mozilla` directory and find the image file there.
+On Linux based hosts, your $HOME directory will automatically be mounted to /home/ffuser/home_home/
+
+You can also copy image files into your host directory: `~/.javafox/.mozilla`.  In the contained javafox you can then browse to the `HOME/.mozilla` directory and find the image file there.
 
 ## Other legacy Firefox versions
 
@@ -99,3 +101,7 @@ Does not work:
   /home/ffuser/entrypoint.sh: line 16:    12 Trace/breakpoint trap   (core dumped) /usr/bin/firefox-esr -no-remote $@
 
 Therefore this container is based on Ubuntu 16.04.
+
+## Tips
+- iLO, use the "Java Applet" instead of "Java Web Start"
+- iDRAC6, issue with Virtual Media when browsing to a folder containing special characters such as 'φ8' - rename or delete these files

--- a/javafox
+++ b/javafox
@@ -11,8 +11,8 @@ if [ "$OS" == "Darwin" ]; then
     DISPLAY=host.docker.internal:0
 fi
 if [ "$OS" == "Linux" ]; then
-   # Mount local home directory
-   HOST_HOME_DIR_PARAM="-v $HOME:/home/ffuser/host_home/"
+   # Mount local home directory (read only), remove :ro for read/write access
+   HOST_HOME_DIR_PARAM="-v $HOME:/home/ffuser/host_home/:ro"
    echo "Mounting host's home directory to /home/ffuser/host_home/"
 fi
 

--- a/javafox
+++ b/javafox
@@ -4,10 +4,16 @@ XSOCK=/tmp/.X11-unix
 XAUTHD="$(mktemp -d)"
 XAUTH="$XAUTHD/xauth"
 OS="$(uname)"
+HOST_HOME_DIR_PARAM=""
 
 if [ "$OS" == "Darwin" ]; then
     xhost + 127.0.0.1
     DISPLAY=host.docker.internal:0
+fi
+if [ "$OS" == "Linux" ]; then
+   # Mount local home directory
+   HOST_HOME_DIR_PARAM="-v $HOME:/home/ffuser/host_home/"
+   echo "Mounting host's home directory to /home/ffuser/host_home/"
 fi
 
 
@@ -34,6 +40,7 @@ touch "${BASE}/.java/deployment/security/exception.sites"
 docker run -ti --rm --net=host -v $XSOCK:$XSOCK -v $XAUTHD:$XAUTHD \
        -e XAUTHORITY=$XAUTH -e DISPLAY=$DISPLAY \
        -v "${BASE}/.java:/home/ffuser/.java" \
+       $HOST_HOME_DIR_PARAM \
        -v "${BASE}/.mozilla:/home/ffuser/.mozilla" ${IMAGE} "$@"
 
 rm -rf $XAUTHD


### PR DESCRIPTION
First of all, fantastic project. 
I fired up a DL380 G7 with iLO3 and was struggling to get virtual console functional, this saved me a ton of time.

This commit automatically mounts the user's home directory as read only to /home/ffuser/host_home/ so virtual drives / virtual media is less of a hassle (moving files around).

I've put a check in place to only perform this action when the host is detected as Linux. I no longer own a Mac so I can't test. The last time I had a Mac I was working on a Magento 2 project and mount binding in docker was extremely slow, perhaps someone could test this functionality on a Mac?


