### PR TITLE
avoid scary stderr messages / resolve GH-15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -q update && \
 
 COPY deb/* /tmp/
 
-RUN dpkg -i /tmp/*.deb; apt-get -fqy install
+RUN apt-get install -y /tmp/*.deb;
+
 
 RUN useradd -m -s /bin/bash -c "Firefox user" ffuser && \
     mkdir -p /etc/sudoers.d && \


### PR DESCRIPTION
avoid scary stderr messages / resolve GH-15

the code also looks nicer/cleaner :)

PS iirc prior to Ubuntu 16.04, apt-get couldn't actually install .deb files, so invoking dpkg is probably how one would do it in Ubuntu <=14.04, and probably why the original code was written with dpkg